### PR TITLE
Rename game to Tank Duel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tank-battle-online",
+  "name": "tank-duel",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tank-battle-online",
+      "name": "tank-duel",
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tank-battle-online",
+  "name": "tank-duel",
   "version": "1.0.0",
-  "description": "Online multiplayer tank battle game",
+  "description": "Online multiplayer tank duel game",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tank Battle Online</title>
+  <title>Tank Duel</title>
   <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="game-container">
     <div id="menu-screen" class="screen">
-      <h1>Tank Battle Online</h1>
+      <h1>Tank Duel</h1>
       <div class="menu-options">
         <button id="create-game">Create Game</button>
         <div class="join-game-container">


### PR DESCRIPTION
## Summary
- update page title and heading to "Tank Duel"
- rename package to `tank-duel` in package.json and lock file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683d1b8b3bfc83309ee0738c44ba1548